### PR TITLE
Make NaughtyAttributes an optional dependency

### DIFF
--- a/Assets/Adrenak.UGX/Runtime/Adrenak.UGX.Runtime.asmdef
+++ b/Assets/Adrenak.UGX/Runtime/Adrenak.UGX.Runtime.asmdef
@@ -13,5 +13,13 @@
     "overrideReferences": false,
     "precompiledReferences": [],
     "autoReferenced": true,
-    "defineConstraints": []
+    "defineConstraints": [],
+    "versionDefines": [
+        {
+            "name": "com.dbrizov.naughtyattributes",
+            "expression": "2.0.4",
+            "define": "UGX_NAUGHTY_AVAILABLE"
+        }
+    ],
+    "noEngineReferences": false
 }

--- a/Assets/Adrenak.UGX/Runtime/Components/Picture/Picture.cs
+++ b/Assets/Adrenak.UGX/Runtime/Components/Picture/Picture.cs
@@ -5,7 +5,10 @@ using UnityEngine.UI;
 
 using Adrenak.Unex;
 using UnityEngine.Events;
+
+#if UGX_NAUGHTY_AVAILABLE
 using NaughtyAttributes;
+#endif
 
 namespace Adrenak.UGX {
     [Serializable]
@@ -63,7 +66,9 @@ namespace Adrenak.UGX {
                 Refresh();
         }
 
+#if UGX_NAUGHTY_AVAILABLE
         [Button("Refresh")]
+#endif
         public void Refresh() {
             if (!Application.isPlaying)
                 return;

--- a/Assets/Adrenak.UGX/Runtime/Navigation/Navigator.cs
+++ b/Assets/Adrenak.UGX/Runtime/Navigation/Navigator.cs
@@ -1,8 +1,11 @@
-﻿using NaughtyAttributes;
-using UnityEngine.Events;
+﻿using UnityEngine.Events;
 using System.Collections.Generic;
 using UnityEngine;
 using Adrenak.Unex;
+
+#if UGX_NAUGHTY_AVAILABLE
+using NaughtyAttributes;
+#endif
 
 namespace Adrenak.UGX {
     public abstract class Navigator : MonoBehaviour {
@@ -23,14 +26,23 @@ namespace Adrenak.UGX {
         [SerializeField] string browserID;
         [SerializeField] bool canPopAll;
 
-        [ReadOnly] [SerializeField] protected Window current = null;
+#if UGX_NAUGHTY_AVAILABLE
+        [ReadOnly]
+#endif
+        [SerializeField] protected Window current = null;
         public Window Current => current;
 
-        [ReadOnly] [ReorderableList] [SerializeField] protected List<Window> history = new List<Window>();
+#if UGX_NAUGHTY_AVAILABLE
+        [ReadOnly] [ReorderableList]
+#endif
+        [SerializeField] protected List<Window> history = new List<Window>();
         public List<Window> History => history;
 
         [SerializeField] protected bool useInitialWindow;
-        [ShowIf("useInitialWindow")] [SerializeField] protected Window initialWindow;
+#if UGX_NAUGHTY_AVAILABLE
+        [ShowIf("useInitialWindow")]
+#endif
+        [SerializeField] protected Window initialWindow;
 #pragma warning restore 0649
 
         // ================================================

--- a/Assets/Adrenak.UGX/Runtime/Tweening/OpacityTweener.cs
+++ b/Assets/Adrenak.UGX/Runtime/Tweening/OpacityTweener.cs
@@ -1,5 +1,4 @@
-﻿using NaughtyAttributes;
-using Cysharp.Threading.Tasks;
+﻿using Cysharp.Threading.Tasks;
 using UnityEngine;
 
 namespace Adrenak.UGX {

--- a/Assets/Adrenak.UGX/Runtime/Tweening/PositionTweener.cs
+++ b/Assets/Adrenak.UGX/Runtime/Tweening/PositionTweener.cs
@@ -1,8 +1,10 @@
 ﻿using Cysharp.Threading.Tasks;
 
-using NaughtyAttributes;
-
 using UnityEngine;
+
+#if UGX_NAUGHTY_AVAILABLE
+using NaughtyAttributes;
+#endif
 
 namespace Adrenak.UGX {
     [DisallowMultipleComponent]
@@ -14,19 +16,36 @@ namespace Adrenak.UGX {
             Right
         }
 
-        [BoxGroup("Positions")] [ReadOnly] [SerializeField] Vector3 inPosition;
+#if UGX_NAUGHTY_AVAILABLE
+        [BoxGroup("Positions")] [ReadOnly]
+#endif
+        [SerializeField] Vector3 inPosition;
         public Vector3 InPosition => inPosition;
 
-        [BoxGroup("Positions")] [ReadOnly] [SerializeField] Vector3 outPosition;
+#if UGX_NAUGHTY_AVAILABLE
+        [BoxGroup("Positions")] [ReadOnly]
+#endif
+        [SerializeField] Vector3 outPosition;
         public Vector3 OutPosition => outPosition;
 
-        [BoxGroup("Config")] public PositionType enterPosition = PositionType.Left;
-        [BoxGroup("Config")] public PositionType exitPosition = PositionType.Right;
+#if UGX_NAUGHTY_AVAILABLE
+        [BoxGroup("Config")]
+#endif
+        public PositionType enterPosition = PositionType.Left;
 
+#if UGX_NAUGHTY_AVAILABLE
+        [BoxGroup("Config")]
+#endif
+        public PositionType exitPosition = PositionType.Right;
+
+#if UGX_NAUGHTY_AVAILABLE
         [Button("Set As In")]
+#endif
         public void CaptureInPosition() => inPosition = RT.localPosition;
 
+#if UGX_NAUGHTY_AVAILABLE
         [Button("Set As Out")]
+#endif
         public void CaptureOutPosition() => outPosition = RT.localPosition;
 
         override async public UniTask TransitionInAsync() {

--- a/Assets/Adrenak.UGX/Runtime/Tweening/TweenerBase.cs
+++ b/Assets/Adrenak.UGX/Runtime/Tweening/TweenerBase.cs
@@ -1,6 +1,9 @@
 ﻿using UnityEngine;
 using Cysharp.Threading.Tasks;
+
+#if UGX_NAUGHTY_AVAILABLE
 using NaughtyAttributes;
+#endif
 
 namespace Adrenak.UGX {
     public abstract class TweenerBase : UGXBehaviour {
@@ -27,7 +30,12 @@ namespace Adrenak.UGX {
             }
         }
 
-        [SerializeField] [ReadOnly] float progress;
+        [SerializeField]
+#if UGX_NAUGHTY_AVAILABLE
+        [ReadOnly]
+#endif
+        float progress;
+
         public float Progress {
             get => progress;
             set {
@@ -36,12 +44,30 @@ namespace Adrenak.UGX {
             }
         }
 
-        [BoxGroup("Tweening Args")] [SerializeField] public bool useSameArgsForInAndOut = true;
-        [BoxGroup("Tweening Args")] [ShowIf("useSameArgsForInAndOut")] public TweenArgs args;
-        [BoxGroup("Tweening Args")] [HideIf("useSameArgsForInAndOut")] public TweenArgs inArgs;
-        [BoxGroup("Tweening Args")] [HideIf("useSameArgsForInAndOut")] public TweenArgs outArgs;
+#if UGX_NAUGHTY_AVAILABLE
+        [BoxGroup("Tweening Args")]
+#endif
+        [SerializeField]
+        public bool useSameArgsForInAndOut = true;
 
+#if UGX_NAUGHTY_AVAILABLE
+        [BoxGroup("Tweening Args")] [ShowIf("useSameArgsForInAndOut")]
+#endif
+        public TweenArgs args;
+
+#if UGX_NAUGHTY_AVAILABLE
+        [BoxGroup("Tweening Args")] [HideIf("useSameArgsForInAndOut")]
+#endif
+        public TweenArgs inArgs;
+
+#if UGX_NAUGHTY_AVAILABLE
+        [BoxGroup("Tweening Args")] [HideIf("useSameArgsForInAndOut")]
+#endif
+        public TweenArgs outArgs;
+
+#if UGX_NAUGHTY_AVAILABLE
         [Button]
+#endif
         async public void TransitionIn() => await TransitionInAsync();
         public abstract UniTask TransitionInAsync();
 

--- a/Assets/Adrenak.UGX/Runtime/Tweening/TweenerBase.cs
+++ b/Assets/Adrenak.UGX/Runtime/Tweening/TweenerBase.cs
@@ -71,7 +71,9 @@ namespace Adrenak.UGX {
         async public void TransitionIn() => await TransitionInAsync();
         public abstract UniTask TransitionInAsync();
 
+#if UGX_NAUGHTY_AVAILABLE
         [Button]
+#endif
         async public void TransitionOut() => await TransitionOutAsync();
         public abstract UniTask TransitionOutAsync();
 

--- a/Assets/Adrenak.UGX/Runtime/View/StatefulView.cs
+++ b/Assets/Adrenak.UGX/Runtime/View/StatefulView.cs
@@ -1,6 +1,9 @@
 ﻿using UnityEngine;
-using NaughtyAttributes;
 using System;
+
+#if UGX_NAUGHTY_AVAILABLE
+using NaughtyAttributes;
+#endif
 
 namespace Adrenak.UGX {
     /// <summary>
@@ -17,11 +20,19 @@ namespace Adrenak.UGX {
         /// Whether the View should update itself with the state it starts with.
         /// </summary>
         [Tooltip("Whether the View should update itself with the state it starts with.")]
-        [BoxGroup("View State")] public bool updateFromStateOnStart = false;
+
+#if UGX_NAUGHTY_AVAILABLE
+        [BoxGroup("View State")]
+#endif 
+        public bool updateFromStateOnStart = false;
 
         [Tooltip("Current state of the view. Changing values inside it will not trigger Update" + 
         "automatically. You must click the Update View button on this component to see the changes.")]
-        [BoxGroup("View State")] [SerializeField] TState state;
+        
+#if UGX_NAUGHTY_AVAILABLE
+        [BoxGroup("View State")]
+#endif
+        [SerializeField] TState state;
 
         /// <summary>
         /// Current state of the View
@@ -53,7 +64,9 @@ namespace Adrenak.UGX {
         /// <summary>
         /// Updates the View using the current state
         /// </summary>
+#if UGX_NAUGHTY_AVAILABLE
         [Button("Update View")]
+#endif
         public void UpdateView() {
 #if UNITY_EDITOR
             UnityEditor.Undo.RecordObject(gameObject, "Update View");

--- a/Assets/Adrenak.UGX/Runtime/View/ViewList.cs
+++ b/Assets/Adrenak.UGX/Runtime/View/ViewList.cs
@@ -3,8 +3,11 @@ using UnityEngine;
 using System.Collections.Generic;
 using System.Collections;
 using UnityEngine.Events;
-using NaughtyAttributes;
 using UnityEngine.UI;
+
+#if UGX_NAUGHTY_AVAILABLE
+using NaughtyAttributes;
+#endif
 
 namespace Adrenak.UGX {
     /// <summary>
@@ -30,13 +33,19 @@ namespace Adrenak.UGX {
         /// The parent under which the elements must be instantiated.
         /// </summary>
         [Tooltip("The parent under which the elements must be instantiated.")]
-        [BoxGroup("Instantiation")] public Transform container = null;
+#if UGX_NAUGHTY_AVAILABLE
+        [BoxGroup("Instantiation")]
+#endif
+        public Transform container = null;
 
         /// <summary>
         /// Template of the element View. Can be prefab or GameObject.
         /// </summary>
         [Tooltip("Template of the element View. Can be prefab or GameObject.")]
-        [BoxGroup("Instantiation")] public View template = null;
+#if UGX_NAUGHTY_AVAILABLE
+        [BoxGroup("Instantiation")]
+#endif
+        public View template = null;
 
         /// <summary>
         /// Whether the list uses the states list in the Start() method to
@@ -47,7 +56,10 @@ namespace Adrenak.UGX {
         public bool populateOnStart = false;
 
         [Tooltip("The states of the current children views")]
-        [BoxGroup("State")] [SerializeField] List<T> currentStates = new List<T>();
+#if UGX_NAUGHTY_AVAILABLE
+        [BoxGroup("State")]
+#endif
+        [SerializeField] List<T> currentStates = new List<T>();
 
         List<StatefulView<T>> Instantiated { get; } = new List<StatefulView<T>>();
         List<UnityAction<StatefulView<T>>> childViewMethods = new List<UnityAction<StatefulView<T>>>();
@@ -93,7 +105,9 @@ namespace Adrenak.UGX {
         /// <summary>
         /// Repopulates all the instances using the current state
         /// </summary>
+#if UGX_NAUGHTY_AVAILABLE
         [Button]
+#endif
         public void Refresh() {
             foreach (var state in currentStates)
                 Destroy(state);

--- a/Assets/Adrenak.UGX/Runtime/Window/Window.cs
+++ b/Assets/Adrenak.UGX/Runtime/Window/Window.cs
@@ -3,7 +3,10 @@ using UnityEngine;
 using System.Linq;
 using UnityEngine.Events;
 using Cysharp.Threading.Tasks;
+
+#if UGX_NAUGHTY_AVAILABLE
 using NaughtyAttributes;
+#endif
 
 namespace Adrenak.UGX {
     /// <summary>
@@ -11,7 +14,11 @@ namespace Adrenak.UGX {
     /// Uses Tweeners to open (Transition Up) and close (Transition Down)
     /// </summary>
     public class Window : UGXBehaviour {
-        [ReadOnly] [SerializeField] WindowStatus status;
+#if UGX_NAUGHTY_AVAILABLE
+        [ReadOnly]
+#endif
+        [SerializeField] WindowStatus status;
+
         /// <summary>
         /// The current status of the window
         /// </summary>
@@ -43,7 +50,9 @@ namespace Adrenak.UGX {
         /// <summary>
         /// Opens the window
         /// </summary>
+#if UGX_NAUGHTY_AVAILABLE
         [Button]
+#endif
         async public void OpenWindow() => await OpenWindowAsync();
 
         /// <summary>
@@ -75,7 +84,9 @@ namespace Adrenak.UGX {
         /// <summary>
         /// Closes the window
         /// </summary>
+#if UGX_NAUGHTY_AVAILABLE
         [Button]
+#endif
         async public void CloseWindow() => await CloseWindowAsync();
 
         /// <summary>

--- a/Assets/Adrenak.UGX/package.json
+++ b/Assets/Adrenak.UGX/package.json
@@ -11,7 +11,6 @@
 	},
 	"dependencies": {
 		"com.pixelplacement.surge.tween": "1.0.2",
-		"com.dbrizov.naughtyattributes": "2.0.4",
 		"com.adrenak.unex": "2.4.0",
 		"com.cysharp.unitask": "2.0.37"
 	},
@@ -20,7 +19,6 @@
 			"name": "package.openupm.com",
 			"url": "https://package.openupm.com",
 			"scopes": [
-				"com.dbrizov.naughtyattributes",
 				"com.cysharp.unitask",
 				"com.openupm"
 			]

--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -1,7 +1,6 @@
 {
   "dependencies": {
     "com.adrenak.unex": "2.4.0",
-    "com.dbrizov.naughtyattributes": "2.0.4",
     "com.pixelplacement.surge.tween": "1.0.2",
     "com.unity.package-manager-ui": "2.0.13",
     "com.unity.modules.ai": "1.0.0",
@@ -42,7 +41,6 @@
       "url": "https://package.openupm.com",
       "scopes": [
         "com.cysharp.unitask",
-        "com.dbrizov.naughtyattributes",
         "com.openupm"
       ]
     },


### PR DESCRIPTION
I'd prefer to use my own editor UI solutions where feasible. However, I also don't want to break existing uses of UGX. So I made NaughtyAttributes an optional dependency.

Note that Unity 2018.4 doesn't support optional dependencies; users of that version will have to install NaughtyAttributes and manually define `UGX_NAUGHTY_AVAILABLE` in their project.